### PR TITLE
Update self link to evashapiro.github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 					</p>
 					<p class="text-muted">
 						<a target="_blank" href="mailto:shapiro@ucsc.edu">shapiro@ucsc.edu</a> <br>
-						<a href="evashapiro.github.io">evashapiro.github.io </a> <br>
+						<a href="Http://evashapiro.github.io">evashapiro.github.io </a> <br>
 						Tel. 925.286.2846 <br>
 						<br>
 						Department of Economics <br>


### PR DESCRIPTION
You needed the http:// in front of that link. 
Otherwise, if ou like on it too many times you'll be lead to a 404 error. 
Forgot what that error causing it is called, every time lpuou click thru you concactinate "evashapiro.github.io" to the url.
